### PR TITLE
Makefile makeover

### DIFF
--- a/.build/dotfiles.txt
+++ b/.build/dotfiles.txt
@@ -1,0 +1,4 @@
+.bash_profile
+.bashrc
+.vimrc
+.gitconfig

--- a/.build/install.sh
+++ b/.build/install.sh
@@ -9,6 +9,8 @@ repo_root=$(dirname "$scriptdir")
 # shellcheck disable=SC2013
 for file in $(cat "$scriptdir/dotfiles.txt")
 do
+    # Some systems will have, say, a `.bash_profile` by default,
+    # so pass -f to overwrite
     ln -sf "$repo_root/$file" "$HOME"
 done
 

--- a/.build/install.sh
+++ b/.build/install.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env sh
 # Do a full installation, from scratch
 set -e
+scriptdir=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>&1 > /dev/null && pwd)
 
-cp .bash_profile ~
-cp .bashrc ~
-cp .vimrc ~
-cp .gitconfig ~
+for file in $(cat "$scriptdir/dotfiles.txt")
+do
+    ln -s "$(realpath "$file")" "$HOME"
+done
 
 if [[ $(uname) == 'Darwin' ]]
 then

--- a/.build/install.sh
+++ b/.build/install.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Do a full installation, from scratch
 set -e
 scriptdir=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>&1 > /dev/null && pwd)
 
@@ -13,11 +12,3 @@ do
     # so pass -f to overwrite
     ln -sf "$repo_root/$file" "$HOME"
 done
-
-if [[ $(uname) == 'Darwin' ]]
-then
-    make brew-cli
-    make brew
-    make npm
-    make conda
-fi

--- a/.build/install.sh
+++ b/.build/install.sh
@@ -1,8 +1,10 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # Do a full installation, from scratch
 set -e
 scriptdir=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>&1 > /dev/null && pwd)
 
+# Disable shellcheck warning for reading words instead of lines
+# shellcheck disable=SC2013
 for file in $(cat "$scriptdir/dotfiles.txt")
 do
     ln -s "$(realpath "$file")" "$HOME"

--- a/.build/install.sh
+++ b/.build/install.sh
@@ -9,7 +9,7 @@ repo_root=$(dirname "$scriptdir")
 # shellcheck disable=SC2013
 for file in $(cat "$scriptdir/dotfiles.txt")
 do
-    ln -s "$repo_root/$file" "$HOME"
+    ln -sf "$repo_root/$file" "$HOME"
 done
 
 if [[ $(uname) == 'Darwin' ]]

--- a/.build/install.sh
+++ b/.build/install.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env sh
+# Do a full installation, from scratch
 set -e
 
 cp .bash_profile ~
 cp .bashrc ~
 cp .vimrc ~
 cp .gitconfig ~
+
+if [[ $(uname) == 'Darwin' ]]
+then
+    make brew-cli
+    make brew
+    make npm
+    make conda
+fi

--- a/.build/install.sh
+++ b/.build/install.sh
@@ -3,11 +3,13 @@
 set -e
 scriptdir=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>&1 > /dev/null && pwd)
 
+repo_root=$(dirname "$scriptdir")
+
 # Disable shellcheck warning for reading words instead of lines
 # shellcheck disable=SC2013
 for file in $(cat "$scriptdir/dotfiles.txt")
 do
-    ln -s "$(realpath "$file")" "$HOME"
+    ln -s "$repo_root/$file" "$HOME"
 done
 
 if [[ $(uname) == 'Darwin' ]]

--- a/.build/uninstall.sh
+++ b/.build/uninstall.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+set -e
+scriptdir=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>&1 > /dev/null && pwd)
+
+for file in $(cat "$scriptdir/dotfiles.txt")
+do
+    rm -f "$HOME/$file"
+done

--- a/.build/uninstall.sh
+++ b/.build/uninstall.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -e
 scriptdir=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>&1 > /dev/null && pwd)
 
+# Disable shellcheck warning for reading words instead of lines
+# shellcheck disable=SC2013
 for file in $(cat "$scriptdir/dotfiles.txt")
 do
     rm -f "$HOME/$file"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,27 +15,22 @@ jobs:
     runs-on: ubuntu-latest 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Install dotfiles
-      run: make install
-
-    - name: Test Bash startup
-      run: |
-        source ~/.bash_profile
-        source ~/.bashrc
+    - run: make install
+    - run: make installcheck
 
   macos:
     runs-on: macos-latest 
     steps:
     - uses: actions/checkout@v2
+    - run: make install
 
-    - name: Run macOS setup
+    # The macOS environment should already have `brew` installed
+    - name: make brew 
       run: |
-        # Without this, `brew.sh` will fail on the Node.js preinstalled in the virtual environment
+        # Without this, `brew bundle` will fail on the Node.js preinstalled in the virtual environment
         brew unlink node@12
-        make bootstrap-macos 
+        make brew
 
-    - name: Test Bash startup
-      run: |
-        source ~/.bash_profile
-        source ~/.bashrc
+    - run: make npm
+    - run: make conda
+    - run: make installcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,13 @@ name: CI
 on: push
 
 jobs:
-  shellcheck:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run shellcheck
-        run: make check
+      - name: lint 
+        run: make lint
 
   linux:
     runs-on: ubuntu-latest 

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,20 @@ all: install installcheck
 
 .PHONY: lint
 lint:
-	./.build/shellcheck.sh
+	.build/shellcheck.sh
 
 .PHONY: install
 install:
-	./.build/install.sh
+	.build/install.sh
 
 .PHONY: installcheck
 installcheck:
 	bash ~/.bash_profile
 	bash ~/.bashrc
+
+.PHONY: uninstall
+uninstall:
+	.build/uninstall.sh
 
 .PHONY: brew-cli
 brew-cli:

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ install:
 
 .PHONY: installcheck
 installcheck:
-	source ~/.bash_profile
-	source ~/.bashrc
+	bash ~/.bash_profile
+	bash ~/.bashrc
 
 .PHONY: brew-cli
 brew-cli:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: install check
+all: install installcheck
 
 .PHONY: lint
 lint:
@@ -9,8 +9,10 @@ lint:
 install:
 	./.build/install.sh
 
-.PHONY: check
-check:
+.PHONY: installcheck
+installcheck:
+	source ~/.bash_profile
+	source ~/.bashrc
 
 .PHONY: brew-cli
 brew-cli:

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
 .PHONY: all
-all: check install
+all: install check
 
-.PHONY: check
-check:
+.PHONY: lint
+lint:
 	./.build/shellcheck.sh
 
 .PHONY: install
 install:
 	./.build/install.sh
+
+.PHONY: check
+check:
 
 .PHONY: brew-cli
 brew-cli:

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,3 @@ npm:
 .PHONY: conda
 conda:
 	macos/conda.sh
-
-.PHONY: bootstrap-macos
-bootstrap-macos: install brew-cli brew npm conda

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is my repository of configuration files.
 
 ```sh
 # This should work on any Linux or macOS system.
-make install
+./bootstrap.sh
 ```
 
 Note that the files for VS Code and iTerm2 must be copied manually.

--- a/README.md
+++ b/README.md
@@ -11,10 +11,4 @@ This is my repository of configuration files.
 make install
 ```
 
-Or, if on macOS, run:
-
-```sh
-make bootstrap-macos
-```
-
 Note that the files for VS Code and iTerm2 must be copied manually.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Do a full installation, from scratch
+set -e
+
+make install
+
+if [[ $(uname) == 'Darwin' ]]
+then
+    make brew-cli
+    make brew
+    make npm
+    make conda
+fi


### PR DESCRIPTION
- Add `bootstrap.sh` that handles all setup from scratch for both Linux and macOS
- Add new `make` targets: `lint`, `installcheck`, and `uninstall`
- Split the Actions workflow into separate steps instead of one long-running step